### PR TITLE
Added check for self.file in process directive loop

### DIFF
--- a/lib/minispade-rails/directive_processor.rb
+++ b/lib/minispade-rails/directive_processor.rb
@@ -39,7 +39,9 @@ module MinispadeRails
 
         @spades ||= []
         each_entry(root) do |pathname|
-          if context.asset_requirable?(pathname)
+          if pathname.to_s == self.file
+            next
+          elsif context.asset_requirable?(pathname)
             context.depend_on pathname
             @spades << pathname
           end

--- a/test/compilation_test.rb
+++ b/test/compilation_test.rb
@@ -18,6 +18,12 @@ class MinispadeTest < ActionController::IntegrationTest
     assert @response.body == "minispade.register(\"foo/test\", \"alert(\\\"foo\\\");\\n\");\n", "Was: #{@response.body.inspect}"
   end
 
+  test "require_spade should not load itself" do
+    get "/assets/application.js"
+    assert_response :success
+    assert_no_match /SystemStackError: stack level too deep/, @response.body, "Was: #{@response.body}"
+  end
+
   # This kinda sucks. If I don't do this, then the assets don't recompile when I change
   # the deferred flag.
   def switch_deferred(flag)

--- a/test/dummy/app/assets/javascripts/application.js
+++ b/test/dummy/app/assets/javascripts/application.js
@@ -4,4 +4,4 @@
 // It's not advisable to add code directly here, but if you do, it'll appear at the bottom of the
 // the compiled file.
 //
-//= require_tree .
+//= require_spade .


### PR DESCRIPTION
This fixes the "stack level too deep" error that occurs when doing `require_spade .`

Related issue: https://github.com/keithpitt/minispade-rails/issues/3
