### PR TITLE
Added sourceURL support to deferred compilation

### DIFF
--- a/lib/minispade-rails/compiler.rb
+++ b/lib/minispade-rails/compiler.rb
@@ -17,6 +17,7 @@ module MinispadeRails
 
     def evaluate(scope, locals, &block)
       if MinispadeRails::Config.deferred
+        data << "//@ sourceURL=#{scope.logical_path}.js"
         "minispade.register(\"#{scope.logical_path}\", #{data.inspect});\n"
       else
         "minispade.register(\"#{scope.logical_path}\", function() { #{data} });\n"

--- a/test/compilation_test.rb
+++ b/test/compilation_test.rb
@@ -15,7 +15,7 @@ class MinispadeTest < ActionController::IntegrationTest
 
     get "/assets/foo/test.js"
     assert_response :success
-    assert @response.body == "minispade.register(\"foo/test\", \"alert(\\\"foo\\\");\\n\");\n", "Was: #{@response.body.inspect}"
+    assert @response.body == "minispade.register(\"foo/test\", \"alert(\\\"foo\\\");\\n//@ sourceURL=foo/test.js\");\n", "Was: #{@response.body.inspect}"
   end
 
   # This kinda sucks. If I don't do this, then the assets don't recompile when I change


### PR DESCRIPTION
I added sourceURL comments to deferred scripts, which gives them file names in the WebKit and Firefox inspectors.
